### PR TITLE
feat: mac init scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ Step one is always to fork this repo!
 
 Prismatopia is a reference implementation, meaning you can clone it, configure, run it and play with it. You make a copy of this repository and that copy becomes the backend for your application. You'll end up customizing your copy of this repository with your resolvers, schemas and other stuff. This repository is simply an empty vessel for you to fork or otherwise copy as the starting point for your API stack.
 
+#### MacOS:
+
+Install docker & docker-compose:
+```
+cd ~/prismatopia && ./macos.sh
+```
+
 ## The Stack
 
 This API is built as a very specific stack of technologies.bThere no options, other than configuring the existing stack components or swapping them out in your own copy. Enjoy!
@@ -74,7 +81,7 @@ Directories:
 * [The Apollo Layer](apollo/README.md)
 * [The Prisma Layer](prisma/README.md)
 * [The AWS Layer](cloudformation/README.md)
-  
+
 ## Running locally
 
 TODO: Fix lazy loading of AWS variables

--- a/macos.sh
+++ b/macos.sh
@@ -17,6 +17,7 @@ install_packages() {
 	)
 
 	brew install ${packages[@]}
+	brew cask install docker
 
 	echo -e "DONE.\n"
 }

--- a/macos.sh
+++ b/macos.sh
@@ -20,3 +20,14 @@ install_packages() {
 
 	echo -e "DONE.\n"
 }
+
+setup_macos() {
+	echo -e "\nSetting up MacOS config...\n"
+
+	setup_homebrew
+	install_packages
+
+	echo -e "DONE.\n"
+}
+
+setup_macos

--- a/macos.sh
+++ b/macos.sh
@@ -7,3 +7,16 @@ setup_homebrew() {
 		/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 	fi
 }
+
+install_packages() {
+	echo -e "\nInstalling Docker for MacOS..."
+
+	declare -a packages=(
+		"docker"
+		"docker-compose"
+	)
+
+	brew install ${packages[@]}
+
+	echo -e "DONE.\n"
+}

--- a/macos.sh
+++ b/macos.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+setup_homebrew() {
+	if [[ ! $(which brew) ]] && [[ ! $(brew --version &> /dev/null) ]]; then
+		echo -e "\nCould not find existing HOMEBREW installation."
+		echo -e "\nNow installing..."
+		/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+	fi
+}


### PR DESCRIPTION
Adds init scripts for Homebrew and then installs docker & docker-compose for MacOS.

This has not been tested, because I don't have a mac!

fixes: #9 